### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/kraftwer1/broccoli-react-templates",
   "dependencies": {
-      "react-templates": "0.1.14",
-      "broccoli-filter": "0.1.10"
+      "react-templates": "0.4.1",
+      "broccoli-filter": "1.2.3"
   }
 }


### PR DESCRIPTION
Update the dependencies of react templates and broccoli for the newest node version

Maybe use the caret ^ or tilde for automatic updates to the newest version?
You could add this to the version 0.0.5 of broccoli-react-templates so that the 0.0.4 still supports the older node versions.

Cheers Roy ;-)
